### PR TITLE
refs qorelanguage/qore#3934 implemented a public API that can be used…

### DIFF
--- a/src/Jvm.cpp
+++ b/src/Jvm.cpp
@@ -84,7 +84,9 @@ void Jvm::destroyVM() {
 }
 
 JNIEnv *Jvm::attachAndGetEnv() {
-    assert(vm != nullptr);
+    if (!vm) {
+        throw UnableToAttachException(JNI_ERR);
+    }
 
     if (env == nullptr) {
         jint err = vm->AttachCurrentThread(reinterpret_cast<void**>(&env), nullptr);
@@ -97,7 +99,9 @@ JNIEnv *Jvm::attachAndGetEnv() {
 }
 
 JNIEnv* Jvm::attachAndGetEnv(bool& new_attach) {
-    assert(vm != nullptr);
+    if (!vm) {
+        throw UnableToAttachException(JNI_ERR);
+    }
 
     if (env == nullptr) {
         jint err = vm->AttachCurrentThread(reinterpret_cast<void**>(&env), nullptr);

--- a/src/defs.h
+++ b/src/defs.h
@@ -300,5 +300,6 @@ extern thread_local QoreThreadAttacher qoreThreadAttacher;
 } // namespace jni
 
 extern "C" DLLEXPORT int jni_module_import(ExceptionSink* xsink, QoreProgram* pgm, const char* import);
+extern "C" DLLEXPORT QoreNamespace* jni_module_find_create_java_namespace(QoreString& arg, QoreProgram* pgm);
 
 #endif // QORE_JNI_DEFS_H_

--- a/src/jni-module.cpp
+++ b/src/jni-module.cpp
@@ -260,15 +260,17 @@ static QoreNamespace* qore_jni_wildcard_import(QoreString& arg, QoreProgram* pgm
     arg.terminate(arg.strlen() - 2);
 
     arg.replaceAll(".", "::");
+    return jni_module_find_create_java_namespace(arg, pgm);
+}
+
+extern "C" QoreNamespace* jni_module_find_create_java_namespace(QoreString& arg, QoreProgram* pgm) {
     arg.concat("::x");
 
-    QoreNamespace* jns;
-
     // create jni namespace in root namespace if necessary
-    jns = pgm->getRootNS()->findLocalNamespace("Jni");
+    QoreNamespace* jns = pgm->getRootNS()->findLocalNamespace("Jni");
 
     QoreNamespace* ns = jns->findCreateNamespacePath(arg.c_str());
-    printd(LogLevel, "jni_module_parse_cmd() nsp: '%s' ns: %p '%s'\n", arg.c_str(), ns, ns->getName());
+    printd(LogLevel, "jni_module_find_create_java_namespace() nsp: '%s' ns: %p '%s'\n", arg.c_str(), ns, ns->getName());
     ns->setClassHandler(jni_class_handler);
 
     return ns;
@@ -536,5 +538,5 @@ QoreClass* jni_class_handler(QoreNamespace* ns, const char* cname) {
         }
         assert(false);
     }
-    return 0;
+    return nullptr;
 }


### PR DESCRIPTION
… to manually import Java classes into other languages

ensure that the jni module can be shut down even if there are dangling global references