### PR TITLE
refs qorelanguage/qore#4091 do not rely on a "long" constructor for d…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,7 @@ generate_java(org/qore/jni/QoreJavaDynamicApi.java)
 generate_java(org/qore/jni/Hash.java 1 2 3 4 5 6 7 8 9 10)
 generate_java(org/qore/jni/JavaClassBuilder.java 1 2 StaticEntry)
 generate_java(org/qore/jni/QoreJavaFileObject.java)
+generate_java(org/qore/jni/QoreJavaObjectPtr.java)
 generate_jar(${BYTE_BUDDY_JAR} JavaJarByteBuddy)
 
 # add Java sources without native methods

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -156,6 +156,9 @@ public:
     DLLLOCAL static GlobalReference<jclass> classQoreObject;                      // org.qore.jni.QoreObject
     DLLLOCAL static jmethodID ctorQoreObject;                                     // QoreObject(long)
 
+    DLLLOCAL static GlobalReference<jclass> classQoreJavaObjectPtr;               // org.qore.jni.QoreJavaObjectPtr
+    DLLLOCAL static jmethodID ctorQoreJavaObjectPtr;                              // QoreJavaObjectPtr(long)
+
     DLLLOCAL static GlobalReference<jclass> classQoreClosure;                     // org.qore.jni.QoreClosure
     DLLLOCAL static jmethodID ctorQoreClosure;                                    // QoreClosure(long)
     DLLLOCAL static jmethodID methodQoreClosureGet;                               // long QoreClosure.get()

--- a/src/java/org/qore/jni/JavaClassBuilder.java
+++ b/src/java/org/qore/jni/JavaClassBuilder.java
@@ -36,6 +36,7 @@ import net.bytebuddy.NamingStrategy;
 import net.bytebuddy.matcher.ElementMatchers;
 
 import org.qore.jni.QoreURLClassLoader;
+import org.qore.jni.QoreJavaObjectPtr;
 
 /** Helper class for building dynamic Java classes
  */
@@ -197,11 +198,11 @@ public class JavaClassBuilder {
 
         // add default constructor for already-created Qore objects
         ArrayList<Type> paramTypes = new ArrayList<Type>();
-        paramTypes.add(Long.TYPE);
+        paramTypes.add(QoreJavaObjectPtr.class);
         bb = (DynamicType.Builder<?>)bb.defineConstructor(Visibility.PUBLIC)
             .withParameters(paramTypes)
             .intercept(
-                MethodCall.invoke(parentClass.getConstructor(Long.TYPE))
+                MethodCall.invoke(parentClass.getConstructor(QoreJavaObjectPtr.class))
                     .onSuper()
                     .withArgument(0)
             );

--- a/src/java/org/qore/jni/QoreJavaClassBase.java
+++ b/src/java/org/qore/jni/QoreJavaClassBase.java
@@ -11,7 +11,7 @@ public abstract class QoreJavaClassBase extends QoreObject {
     }
 
     //! creates the wrapper object with a pointer to an object; this Java object holds a weak reference to the Qore object passed here
-    public QoreJavaClassBase(long obj) {
-        super(obj);
+    public QoreJavaClassBase(QoreJavaObjectPtr obj) {
+        super(obj.ptr);
     }
 }

--- a/src/java/org/qore/jni/QoreJavaObjectPtr.java
+++ b/src/java/org/qore/jni/QoreJavaObjectPtr.java
@@ -1,0 +1,15 @@
+package org.qore.jni;
+
+//! Helper class for pointer arguments to weak references Qore objects
+/** This class is used as the constructor argument in order to not conflict with native arguments taking a Qore "int"
+
+    @since 2.0
+ */
+public class QoreJavaObjectPtr {
+    public long ptr;
+
+    //! creates the wrapper object with a pointer to an object; this Java object holds a weak reference to the Qore object passed here
+    public QoreJavaObjectPtr(long ptr) {
+        this.ptr = ptr;
+    }
+}

--- a/test/jni.qtest
+++ b/test/jni.qtest
@@ -1146,27 +1146,45 @@ lorem ipsum\r
             assertEq(85, ex.line);
         }
 
-        # test Hash APIs
-        assertEq(True, QoreJavaApiTest::testHashBool({"a": True}, "a"));
-        assertEq(1, QoreJavaApiTest::testHashInt({"a": new Integer(1)}, "a"));
-        assertEq(1.0, QoreJavaApiTest::testHashDouble({"a": 1.0}, "a"));
-        assertEq(2020-03-28, QoreJavaApiTest::testHashADate({"a": 2020-03-28}, "a"));
-        assertEq(<abcdef>, QoreJavaApiTest::testHashBinary({"a": <abcdef>}, "a"));
-        assertEq("test", QoreJavaApiTest::testHashString({"a": "test"}, "a"));
-        assertEq((1, "two", True), QoreJavaApiTest::testHashList({"a": (1, "two", True)}, "a"));
-        assertEq({"a": 1, "b": "two"}, QoreJavaApiTest::testHashListIterator({"a": (1,), "b": ("two",)}));
-        assertEq(True, QoreJavaApiTest::testHashAsBool({"a": 1}, "a"));
-        assertEq(True, QoreJavaApiTest::testHashAsBool({"a": "true"}, "a"));
-        assertEq(True, QoreJavaApiTest::testHashAsBool({"a": "1"}, "a"));
-        assertEq(1, QoreJavaApiTest::testHashAsInt({"a": 1.0}, "a"));
-        assertEq(1, QoreJavaApiTest::testHashAsByte({"a": True}, "a"));
-        assertEq(1, QoreJavaApiTest::testHashAsShort({"a": True}, "a"));
-        assertEq(1, QoreJavaApiTest::testHashAsInt({"a": True}, "a"));
-        assertEq(1, QoreJavaApiTest::testHashAsLong({"a": True}, "a"));
-        assertEq(1.0, QoreJavaApiTest::testHashAsFloat({"a": True}, "a"));
-        assertEq(1.0, QoreJavaApiTest::testHashAsDouble({"a": True}, "a"));
-        assertEq(1.0, QoreJavaApiTest::testHashAsDouble({"a": 1}, "a"));
-        assertEq("1", QoreJavaApiTest::testHashAsString({"a": 1}, "a"));
+        try {
+            # test Hash APIs
+            assertEq(True, QoreJavaApiTest::testHashBool({"a": True}, "a"));
+            assertEq(1, QoreJavaApiTest::testHashInt({"a": new Integer(1)}, "a"));
+            assertEq(1.0, QoreJavaApiTest::testHashDouble({"a": 1.0}, "a"));
+            assertEq(2020-03-28, QoreJavaApiTest::testHashADate({"a": 2020-03-28}, "a"));
+            assertEq(<abcdef>, QoreJavaApiTest::testHashBinary({"a": <abcdef>}, "a"));
+            assertEq("test", QoreJavaApiTest::testHashString({"a": "test"}, "a"));
+            assertEq((1, "two", True), QoreJavaApiTest::testHashList({"a": (1, "two", True)}, "a"));
+            assertEq({"a": 1, "b": "two"}, QoreJavaApiTest::testHashListIterator({"a": (1,), "b": ("two",)}));
+            assertEq(True, QoreJavaApiTest::testHashAsBool({"a": 1}, "a"));
+            assertEq(True, QoreJavaApiTest::testHashAsBool({"a": "true"}, "a"));
+            assertEq(True, QoreJavaApiTest::testHashAsBool({"a": "1"}, "a"));
+            assertEq(1, QoreJavaApiTest::testHashAsInt({"a": 1.0}, "a"));
+            assertEq(1, QoreJavaApiTest::testHashAsByte({"a": True}, "a"));
+            assertEq(1, QoreJavaApiTest::testHashAsShort({"a": True}, "a"));
+            assertEq(1, QoreJavaApiTest::testHashAsInt({"a": True}, "a"));
+            assertEq(1, QoreJavaApiTest::testHashAsLong({"a": True}, "a"));
+            assertEq(1.0, QoreJavaApiTest::testHashAsFloat({"a": True}, "a"));
+            assertEq(1.0, QoreJavaApiTest::testHashAsDouble({"a": True}, "a"));
+            assertEq(1.0, QoreJavaApiTest::testHashAsDouble({"a": 1}, "a"));
+            assertEq("1", QoreJavaApiTest::testHashAsString({"a": 1}, "a"));
+        } catch (hash<ExceptionInfo> ex) {
+            if (ex.arg.typeCode() == NT_OBJECT) {
+                object arg = ex.arg;
+                while (arg && arg.hasCallableMethod("getCause")) {
+                    *object next = arg.getCause();
+                    if (next) {
+                        arg = next;
+                    } else {
+                        break;
+                    }
+                }
+                printf("%s\n", arg.toString());
+                arg.printStackTrace();
+            }
+            printf("%s\n", get_exception_string(ex));
+            rethrow;
+        }
 
         QoreJavaApiTest::testHash1();
         assertEq({"a": 1}, TestHelper::getHash());


### PR DESCRIPTION
…ynamic class creation as it will clash with generated constructors; use a special class to carry the QoreObject ptr instead