### PR TITLE
refs qorelanguage/qore#4371 fixed a bug where the Qore Program and Ja…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(qore-jni-module)
 
 set (VERSION_MAJOR 2)
 set (VERSION_MINOR 0)
-set (VERSION_PATCH 5)
+set (VERSION_PATCH 6)
 
 set (BYTE_BUDDY_JAR ${CMAKE_SOURCE_DIR}/byte-buddy/byte-buddy-1.10.20.jar)
 

--- a/docs/mainpage.dox.tmpl
+++ b/docs/mainpage.dox.tmpl
@@ -722,6 +722,14 @@ set_save_object_callback(callback);
 
     @section jnireleasenotes jni Module Release Notes
 
+    @subsection jni_2_0_6 jni Module Version 2.0.6
+    - fixed a bug where Java method args in array format were not always converted from %Qore values correctly
+      (<a href="https://github.com/qorelanguage/qore/issues/4372">issue 4372</a>)
+    - fixed a bug where the %Qore \c Program and Java \c ClassLoader context was not always set correctly when
+      instantiating %Qore classes from Java when there were dependencies on dynamic classes, leading to class
+      resolution errors
+      (<a href="https://github.com/qorelanguage/qore/issues/4371">issue 4371</a>)
+
     @subsection jni_2_0_5 jni Module Version 2.0.5
     - fixed a memory error in exception handling in %Qore to Java tyype conversions that could cause a core dump
       (<a href="https://github.com/qorelanguage/qore/issues/4349">issue 4349</a>)

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -134,6 +134,7 @@ public:
     DLLLOCAL static jmethodID methodConstructorToString;                          // String Constructor.toString()
     DLLLOCAL static jmethodID methodConstructorGetModifiers;                      // int Constructor.getModifiers()
     DLLLOCAL static jmethodID methodConstructorIsVarArgs;                         // boolean Constructor.isVarArgs()
+    DLLLOCAL static jmethodID methodConstructorNewInstance;                       // Object newInstance(Object...)
 
     DLLLOCAL static GlobalReference<jclass> classQoreInvocationHandler;           // org.qore.jni.QoreInvocationHandler
     DLLLOCAL static jmethodID ctorQoreInvocationHandler;                          // QoreInvocationHandler(long)

--- a/src/Method.h
+++ b/src/Method.h
@@ -54,7 +54,7 @@ public:
      * \param id the method id
      * \param isStatic true if the method is static
      */
-    BaseMethod(Class *cls, jmethodID id, bool isStatic) : cls(cls), id(id) {
+    BaseMethod(Class* cls, jmethodID id, bool isStatic) : cls(cls), id(id) {
         printd(LogLevel, "BaseMethod::BaseMethod(), this: %p, cls: %p, id: %p\n", this, cls, id);
         Env env;
         method = env.toReflectedMethod(cls->getJavaObject(), id, isStatic).makeGlobal();
@@ -71,12 +71,24 @@ public:
         Env env;
         id = env.fromReflectedMethod(method);
         this->method = GlobalReference<jobject>::fromLocal(method);
-        printd(LogLevel, "BaseMethod::BaseMethod(), this: %p, cls: %p, id: %p\n", this, cls, id);
+        printd(LogLevel, "BaseMethod::BaseMethod() this: %p cls: %p id: %p\n", this, cls, id);
+        init(env);
+    }
+
+    /**
+     * \brief Constructor.
+     * \param method an instance of java.lang.reflect.Method
+     * \cls the Class object for the method
+     */
+    DLLLOCAL BaseMethod(Env& env, jobject method, Class* cls) : cls(cls) {
+        id = env.fromReflectedMethod(method);
+        this->method = GlobalReference<jobject>::fromLocal(method);
+        printd(LogLevel, "BaseMethod::BaseMethod() this: %p cls: %p id: %p\n", this, cls, id);
         init(env);
     }
 
     DLLLOCAL ~BaseMethod() {
-        printd(LogLevel, "BaseMethod::~BaseMethod(), this: %p, cls: %p, id: %p\n", this, cls, id);
+        printd(LogLevel, "BaseMethod::~BaseMethod() this: %p cls: %p id: %p\n", this, cls, id);
 
         /*
         Env env;
@@ -209,7 +221,7 @@ protected:
 
     Class* cls;
     jmethodID id;
-    GlobalReference<jobject> method;             // the instance of java.lang.reflect.Method
+    GlobalReference<jobject> method;     // the instance of java.lang.reflect.Method or java.lang.reflect.Constructor
     GlobalReference<jclass> retValClass;
     Type retValType;
     std::vector<std::pair<Type, GlobalReference<jclass>>> paramTypes;

--- a/src/QoreJniClassMap.h
+++ b/src/QoreJniClassMap.h
@@ -292,6 +292,11 @@ public:
         return dynamicApi;
     }
 
+    DLLLOCAL jmethodID getNewInstanceId() const {
+        assert(methodQoreJavaDynamicApiNewInstance);
+        return methodQoreJavaDynamicApiNewInstance;
+    }
+
     DLLLOCAL jmethodID getInvokeMethodId() const {
         assert(methodQoreJavaDynamicApiInvokeMethod);
         return methodQoreJavaDynamicApiInvokeMethod;
@@ -393,6 +398,8 @@ protected:
     // call reference for saving object references
     ResolvedCallReferenceNode* save_object_callback = nullptr;
 
+    // QoreJavaDynamicApi.newInstance()
+    jmethodID methodQoreJavaDynamicApiNewInstance = 0;
     // QoreJavaDynamicApi.invokeNethod()
     jmethodID methodQoreJavaDynamicApiInvokeMethod = 0;
     // QoreJavaDynamicApi.invokeNethodNonvirtual()
@@ -417,6 +424,9 @@ protected:
     bool override_compat_types = false;
     // compat-types values
     bool compat_types = false;
+
+    // initializes the dynamic API in the constructor
+    DLLLOCAL void initDynamicApi(Env& env);
 
     // returns Java byte code (byte[]) for the given Qore class
     DLLLOCAL LocalReference<jbyteArray> generateByteCodeIntern(Env& env, jobject class_loader,

--- a/src/QoreToJava.cpp
+++ b/src/QoreToJava.cpp
@@ -157,18 +157,35 @@ jobject QoreToJava::toObject(const QoreValue& value, jclass cls, JniExternalProg
             }
 
             case NT_INT: {
-                if (env.isSameObject(cls, Globals::classInteger)
-                    || env.isSameObject(cls, Globals::classPrimitiveInt)) {
-                    jvalue arg;
-                    int64 v = value.getAsBigInt();
-                    arg.i = (int)v;
-                    return env.newObject(Globals::classInteger, Globals::ctorInteger, &arg).release();
-                }
                 if (env.isSameObject(cls, Globals::classLong) || env.isSameObject(cls, Globals::classPrimitiveLong)) {
                     jvalue arg;
                     int64 v = value.getAsBigInt();
-                    arg.j = v;
+                    arg.j = (jlong)v;
                     return env.newObject(Globals::classLong, Globals::ctorLong, &arg).release();
+                }
+                if (env.isSameObject(cls, Globals::classInteger) || env.isSameObject(cls, Globals::classPrimitiveInt)) {
+                    jvalue arg;
+                    int64 v = value.getAsBigInt();
+                    arg.i = (jint)v;
+                    return env.newObject(Globals::classInteger, Globals::ctorInteger, &arg).release();
+                }
+                if (env.isSameObject(cls, Globals::classShort) || env.isSameObject(cls, Globals::classPrimitiveShort)) {
+                    jvalue arg;
+                    int64 v = value.getAsBigInt();
+                    arg.s = (jshort)v;
+                    return env.newObject(Globals::classShort, Globals::ctorShort, &arg).release();
+                }
+                if (env.isSameObject(cls, Globals::classCharacter) || env.isSameObject(cls, Globals::classPrimitiveChar)) {
+                    jvalue arg;
+                    int64 v = value.getAsBigInt();
+                    arg.s = (jchar)v;
+                    return env.newObject(Globals::classCharacter, Globals::ctorCharacter, &arg).release();
+                }
+                if (env.isSameObject(cls, Globals::classByte) || env.isSameObject(cls, Globals::classPrimitiveByte)) {
+                    jvalue arg;
+                    int64 v = value.getAsBigInt();
+                    arg.s = (jbyte)v;
+                    return env.newObject(Globals::classByte, Globals::ctorByte, &arg).release();
                 }
                 break;
             }

--- a/src/java/org/qore/jni/QoreJavaDynamicApi.java
+++ b/src/java/org/qore/jni/QoreJavaDynamicApi.java
@@ -24,14 +24,30 @@ package org.qore.jni;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
-import java.lang.reflect.Field;
 
 //! This class provides methods that allow Java to interface with Qore code
 /**
  */
 public class QoreJavaDynamicApi {
+    //! creates an instance of the given class
+    public static Object newInstance(Constructor<?> c, Object... args) throws Throwable {
+        try {
+            c.trySetAccessible();
+            return c.newInstance(args);
+        } catch (InvocationTargetException e) {
+            Throwable e0 = e;
+            while (e0 instanceof InvocationTargetException) {
+                e0 = e0.getCause();
+            }
+            throw e0;
+        }
+    }
+
     //! invokes the given method on the given object and returns the return value
     public static Object invokeMethod(Method m, Object obj, Object... args) throws Throwable {
         try {

--- a/src/java/org/qore/jni/QoreURLClassLoader.java
+++ b/src/java/org/qore/jni/QoreURLClassLoader.java
@@ -356,6 +356,14 @@ public class QoreURLClassLoader extends URLClassLoader {
      * Loads classes; returns pending classes injected by the jni module or the compiler
      */
     public Class<?> loadClass(String bin_name) throws ClassNotFoundException {
+        /*
+        // XXX DELETEME DEBUG
+        if (bin_name.equals("org.apache.kafka.clients.consumer.KafkaConsumer")
+            || bin_name.equals("org.apache.kafka.common.header.Headers")) {
+            System.out.println(String.format("loadClass(%s) %x (pgm %x)", bin_name, hashCode(), pgm_ptr));
+        }
+        */
+
         //System.out.printf("QoreURLClassLoader.loadClass() this: %x '%s' pgm: %x (bootstrap: %s startup: %s)\n",
         //    hashCode(), bin_name, pgm_ptr, bootstrap, startup);
         Class<?> rv = findLoadedClass(bin_name);
@@ -541,7 +549,7 @@ public class QoreURLClassLoader extends URLClassLoader {
 
     //! Adds a path to the classpath
     public void addPath(String classpath) {
-        //debugLog("addPath: " + classpath);
+        //debugLog(String.format("%x: addPath: %s", hashCode(), classpath));
         String seps = File.pathSeparator; // separators
 
         // want to accept both system separator and ';'

--- a/src/java/org/qore/jni/compiler/QoreJavaCompiler.java
+++ b/src/java/org/qore/jni/compiler/QoreJavaCompiler.java
@@ -402,7 +402,7 @@ public class QoreJavaCompiler<T> {
     }
 
     public void injectClass(String binName, byte[] byteCode) {
-        System.out.printf("inject class %s: %d bytes\n", binName, byteCode.length);
+        //System.out.printf("inject class %s: %d bytes\n", binName, byteCode.length);
         classLoader.addPendingClass(binName, byteCode);
     }
 

--- a/src/jni-module.cpp
+++ b/src/jni-module.cpp
@@ -383,7 +383,6 @@ static void qore_jni_mc_add_classpath(const QoreString& cmd_arg, QoreProgram* pg
     QoreString arg(cmd_arg);
     q_env_subst(arg);
     printd(LogLevel, "qore_jni_mc_add_classpath() jpc: %p arg: '%s'\n", jpc, arg.c_str());
-
     jpc->addClasspath(arg.c_str());
 }
 
@@ -394,9 +393,10 @@ static void qore_jni_mc_add_relative_classpath(const QoreString& arg, QoreProgra
     cwd_str = pgm->getScriptDir();
 
     if (!cwd_str) {
-        char* cwd = getcwd(0, 0);
+        char* cwd = getcwd(nullptr, 0);
         if (!cwd) {
-            throw QoreJniException("JNI-ADD-RELATIVE-CLASSPATH-ERROR", "cannot determine relative path; there is no information in the Program context and cannot get current working directory: %s", strerror(errno));
+            throw QoreJniException("JNI-ADD-RELATIVE-CLASSPATH-ERROR", "cannot determine relative path; there is no " \
+                "information in the Program context and cannot get current working directory: %s", strerror(errno));
         }
         ON_BLOCK_EXIT(free, cwd);
         cwd_str = new QoreStringNode(cwd);

--- a/test/jni-compat.qtest
+++ b/test/jni-compat.qtest
@@ -37,7 +37,7 @@ public class Main inherits QUnit::Test {
         Field oa = clazz.getDeclaredField("oa");
         Field ia = clazz.getDeclaredField("ia");
 
-        binary byteArray = ba.get();
+        list<int> byteArray = ba.get();
         list<auto> objectArray = oa.get();
         list<auto> intArray = ia.get();
 
@@ -63,7 +63,7 @@ public class Main inherits QUnit::Test {
         Field oa = clazz.getDeclaredField("oa");
         Field ia = clazz.getDeclaredField("ia");
 
-        binary byteArray = ba.get(instance);
+        list<int> byteArray = ba.get(instance);
         list<auto> objectArray = oa.get(instance);
         list<auto> intArray = ia.get(instance);
 

--- a/test/jni.qtest
+++ b/test/jni.qtest
@@ -743,17 +743,17 @@ public class QoreArgTest extends ArgTest {
 To: target@bar.cz\r
 Subject: foo bar\r
 MIME-Version: 1.0\r
-Content-Type: multipart/mixed;boundary=MjAxNjAxMjIxMTQ4MDg\r
+Content-Type: multipart/mixed; boundary=MjAxNjAxMjIxMTQ4MDg\r
 \r
 This is a MIME multipart message\r
 --MjAxNjAxMjIxMTQ4MDg\r
-Content-Type: text/plain;charset=UTF-8\r
+Content-Type: text/plain; charset=UTF-8\r
 Content-Disposition: inline\r
 Content-Transfer-Encoding: quoted-printable\r
 \r
 some body\r
 --MjAxNjAxMjIxMTQ4MDg\r
-Content-Type: text/plain;charset=UTF-8\r
+Content-Type: text/plain; name=\"foo.txt\"; charset=UTF-8\r
 Content-Disposition: attachment; filename=\"foo.txt\"\r
 Content-Transfer-Encoding: base64\r
 \r
@@ -778,17 +778,17 @@ bG9yZW0gaXBzdW0=\r
 To: target@bar.cz\r
 Subject: foo bar\r
 MIME-Version: 1.0\r
-Content-Type: multipart/mixed;boundary=MjAxNjAxMjIxMTQ4MDg\r
+Content-Type: multipart/mixed; boundary=MjAxNjAxMjIxMTQ4MDg\r
 \r
 This is a MIME multipart message\r
 --MjAxNjAxMjIxMTQ4MDg\r
-Content-Type: text/plain;charset=UTF-8\r
+Content-Type: text/plain; charset=UTF-8\r
 Content-Disposition: inline\r
 Content-Transfer-Encoding: quoted-printable\r
 \r
 body\r
 --MjAxNjAxMjIxMTQ4MDg\r
-Content-Type: text/plain;charset=UTF-8\r
+Content-Type: text/plain; name=\"foo.txt\"; charset=UTF-8\r
 Content-Disposition: attachment; filename=\"foo.txt\"\r
 Content-Transfer-Encoding: quoted-printable\r
 \r
@@ -1431,88 +1431,106 @@ lorem ipsum\r
     }
 
     testStaticMethods() {
-        lang::Class clazz = load_class("org/qore/jni/test/StaticMethods");
+        try {
+            lang::Class clazz = load_class("org/qore/jni/test/StaticMethods");
 
-        # the purpose is to test all possible argument and return value types
-        Method set = clazz.getDeclaredMethod("set", Integer::TYPE);
-        Method get = clazz.getDeclaredMethod("get");                                       # overloaded
-        Method cmp = clazz.getDeclaredMethod("cmp", (Short::TYPE, Long::TYPE));
-        Method add = clazz.getDeclaredMethod("add", (Byte::TYPE, Character::TYPE));
-        Method get2 = clazz.getDeclaredMethod("get", Boolean::TYPE);                    # overloaded
-        Method avg = clazz.getDeclaredMethod("avg", (Byte::TYPE, Byte::TYPE, Byte::TYPE)); # overloaded
-        Method max = clazz.getDeclaredMethod("max", (Long::TYPE, Long::TYPE));
-        Method avg2 = clazz.getDeclaredMethod("avg", (Float::TYPE, Float::TYPE));          # overloaded
-        Method avg3 = clazz.getDeclaredMethod("avg", (Double::TYPE, Double::TYPE));        # overloaded
-        Method wrap = clazz.getDeclaredMethod("wrap", Integer::TYPE);
-        Method unwrap = clazz.getDeclaredMethod("unwrap", load_class("java/lang/Integer"));
-        Method getLongArray = clazz.getDeclaredMethod("getLongArray");
-        Method useArray = clazz.getDeclaredMethod("useArray", load_class("[Ljava/lang/Object;"));
+            # the purpose is to test all possible argument and return value types
+            Method set = clazz.getDeclaredMethod("set", Integer::TYPE);
+            Method get = clazz.getDeclaredMethod("get");                                       # overloaded
+            Method cmp = clazz.getDeclaredMethod("cmp", (Short::TYPE, Long::TYPE));
+            Method add = clazz.getDeclaredMethod("add", (Byte::TYPE, Character::TYPE));
+            Method get2 = clazz.getDeclaredMethod("get", Boolean::TYPE);                    # overloaded
+            Method avg = clazz.getDeclaredMethod("avg", (Byte::TYPE, Byte::TYPE, Byte::TYPE)); # overloaded
+            Method max = clazz.getDeclaredMethod("max", (Long::TYPE, Long::TYPE));
+            Method avg2 = clazz.getDeclaredMethod("avg", (Float::TYPE, Float::TYPE));          # overloaded
+            Method avg3 = clazz.getDeclaredMethod("avg", (Double::TYPE, Double::TYPE));        # overloaded
+            Method wrap = clazz.getDeclaredMethod("wrap", Integer::TYPE);
+            Method unwrap = clazz.getDeclaredMethod("unwrap", load_class("java/lang/Integer"));
+            Method getLongArray = clazz.getDeclaredMethod("getLongArray");
+            Method useArray = clazz.getDeclaredMethod("useArray", load_class("[Ljava/lang/Object;"));
 
-        # set() expects one argument
-        assertThrows("JNI-ERROR", "java.lang.IllegalArgumentException", sub() { set.invoke(); });
+            # set() expects one argument
+            assertThrows("JNI-ERROR", "java.lang.IllegalArgumentException", sub() { set.invoke(); });
 
-        # get() expects no arguments
-        assertThrows("JNI-ERROR", "java.lang.IllegalArgumentException", sub() { get.invoke(NOTHING, 123); });
+            # get() expects no arguments
+            assertThrows("JNI-ERROR", "java.lang.IllegalArgumentException", sub() { get.invoke(NOTHING, 123); });
 
-        # FIXME: why doesn't this fail anymore with Java 12?
-        #assertThrows("JNI-ERROR", "?", sub() { get.invoke(123); });
+            # FIXME: why doesn't this fail anymore with Java 12?
+            #assertThrows("JNI-ERROR", "?", sub() { get.invoke(123); });
 
-        # cmp() expects two arguments
-        assertThrows("JNI-ERROR", "java.lang.IllegalArgumentException", sub() { cmp.invoke(NOTHING, 1); });
-        assertThrows("JNI-ERROR", "java.lang.IllegalArgumentException", sub() { cmp.invoke(NOTHING, (1, 2, 3)); });
+            # cmp() expects two arguments
+            assertThrows("JNI-ERROR", "java.lang.IllegalArgumentException", sub() { cmp.invoke(NOTHING, 1); });
+            assertThrows("JNI-ERROR", "java.lang.IllegalArgumentException", sub() { cmp.invoke(NOTHING, (1, 2, 3)); });
 
-        # set() has no retval, we test the side effect below using get()
-        set.invoke(NOTHING, new Integer(42));
+            # set() has no retval, we test the side effect below using get()
+            set.invoke(NOTHING, new Integer(42));
 
-        # get() returns the value previously passed to set()
-        assertEq(42, get.invoke());
+            # get() returns the value previously passed to set()
+            assertEq(42, get.invoke());
 
-        # cmp() 'converts' first arg to short and returns true if it is greater than the second argument
-        assertTrue(cmp.invoke(NOTHING, (new Short(1000), new Long(-1234567890123))));
-        assertTrue(cmp.invoke(NOTHING, (new Short(32767), new Long(1))));
-        assertFalse(cmp.invoke(NOTHING, (new Short(32768), new Long(1))));  #the first argument overflows to -32768, which is not greater than 1
+            # cmp() 'converts' first arg to short and returns true if it is greater than the second argument
+            assertTrue(cmp.invoke(NOTHING, (new Short(1000), new Long(-1234567890123))));
+            assertTrue(cmp.invoke(NOTHING, (new Short(32767), new Long(1))));
+            assertFalse(cmp.invoke(NOTHING, (new Short(32768), new Long(1))));  #the first argument overflows to -32768, which is not greater than 1
 
-        # add() 'converts' first arg to byte (signed 8bit), second arg to char (unsigned 16bit) and adds them together
-        assertEq(32768, add.invoke(NOTHING, (new Byte(1), new Character(32767))));
-        assertEq(0, add.invoke(NOTHING, (new Byte(36), new Character(65500))));
-        assertEq(65530, add.invoke(NOTHING, (new Byte(-5), new Character(-1))));      #-1 is 65535
-        assertEq(999, add.invoke(NOTHING, (new Byte(255), new Character(1000))));     #255 is -1
+            # add() 'converts' first arg to byte (signed 8bit), second arg to char (unsigned 16bit) and adds them together
+            assertEq(32768, add.invoke(NOTHING, (new Byte(1), new Character(32767))));
+            assertEq(0, add.invoke(NOTHING, (new Byte(36), new Character(65500))));
+            assertEq(65530, add.invoke(NOTHING, (new Byte(-5), new Character(-1))));      #-1 is 65535
+            assertEq(999, add.invoke(NOTHING, (new Byte(255), new Character(1000))));     #255 is -1
 
-        # get2() throws if called with true, otherwise returns 2^63-1
-        assertThrows("JNI-ERROR", sub() { get2.invoke(NOTHING, True); });
-        assertEq(0x7FFFFFFFFFFFFFFF, get2.invoke(NOTHING, False));
+            # get2() throws if called with true, otherwise returns 2^63-1
+            assertThrows("JNI-ERROR", sub() { get2.invoke(NOTHING, True); });
+            assertEq(0x7FFFFFFFFFFFFFFF, get2.invoke(NOTHING, False));
 
-        # avg() 'converts' all args to byte and returns their average
-        assertEq(2, avg.invoke(NOTHING, (new Byte(1), new Byte(2), new Byte(3))));
-        assertEq(85, avg.invoke(NOTHING, (new Byte(126), new Byte(2), new Byte(127))));
-        assertEq(-43, avg.invoke(NOTHING, (new Byte(128), new Byte(256), new Byte(-1))));  #128 -> -128, 256 -> 0
+            # avg() 'converts' all args to byte and returns their average
+            assertEq(2, avg.invoke(NOTHING, (new Byte(1), new Byte(2), new Byte(3))));
+            assertEq(85, avg.invoke(NOTHING, (new Byte(126), new Byte(2), new Byte(127))));
+            assertEq(-43, avg.invoke(NOTHING, (new Byte(128), new Byte(256), new Byte(-1))));  #128 -> -128, 256 -> 0
 
-        # max() compares the arguments, converts the larger to short and returns it
-        assertEq(10, max.invoke(NOTHING, (10, -4)));
-        assertEq(-1, max.invoke(NOTHING, (65535, 0)));
-        assertEq(-32768, max.invoke(NOTHING, (32768, 32768)));
+            # max() compares the arguments, converts the larger to short and returns it
+            assertEq(10, max.invoke(NOTHING, (10, -4)));
+            assertEq(-1, max.invoke(NOTHING, (65535, 0)));
+            assertEq(-32768, max.invoke(NOTHING, (32768, 32768)));
 
-        # avg2() 'converts' all args to float and returns their average
-        assertFloatEq(2.92, avg2.invoke(NOTHING, (new Float(3.14), new Float(2.7))), 0.0000001);
+            # avg2() 'converts' all args to float and returns their average
+            assertFloatEq(2.92, avg2.invoke(NOTHING, (new Float(3.14), new Float(2.7))), 0.0000001);
 
-        # avg3() returns the average of its arguments
-        assertFloatEq(2.92, avg3.invoke(NOTHING, (3.14, 2.7)), 0.00000000000000001);
+            # avg3() returns the average of its arguments
+            assertFloatEq(2.92, avg3.invoke(NOTHING, (3.14, 2.7)), 0.00000000000000001);
 
-        # wrap() & unwrap()
-        assertEq(42, wrap.invoke(NOTHING, new Integer(42)));
-        assertEq(42, unwrap.invoke(NOTHING, new Integer(42)));
-        assertEq(-123, unwrap.invoke(NOTHING, (NOTHING,)));
-        assertThrows("JNI-ERROR", sub() { unwrap.invoke(NOTHING, True); });
-        assertThrows("JNI-ERROR", sub() { unwrap.invoke(1); });
+            # wrap() & unwrap()
+            assertEq(42, wrap.invoke(NOTHING, new Integer(42)));
+            assertEq(42, unwrap.invoke(NOTHING, new Integer(42)));
+            assertEq(-123, unwrap.invoke(NOTHING, (NOTHING,)));
+            assertThrows("JNI-ERROR", sub() { unwrap.invoke(NOTHING, True); });
+            assertThrows("JNI-ERROR", sub() { unwrap.invoke(1); });
 
-        Integer i(10);
-        Integer i2 = i;
-        delete i2;
-        assertThrows("OBJECT-ALREADY-DELETED", sub() { i.hashCode(); });
+            Integer i(10);
+            Integer i2 = i;
+            delete i2;
+            assertThrows("OBJECT-ALREADY-DELETED", sub() { i.hashCode(); });
 
-        # arrays
-        list<auto> longArray = getLongArray.invoke();
-        useArray.invoke(NOTHING, (longArray,));
+            # arrays
+            list<auto> longArray = getLongArray.invoke();
+            useArray.invoke(NOTHING, (longArray,));
+        } catch (hash<ExceptionInfo> ex) {
+            if (ex.arg.typeCode() == NT_OBJECT) {
+                object arg = ex.arg;
+                while (arg && arg.hasCallableMethod("getCause")) {
+                    *object next = arg.getCause();
+                    if (next) {
+                        arg = next;
+                    } else {
+                        break;
+                    }
+                }
+                printf("%s\n", arg.toString());
+                arg.printStackTrace();
+            }
+            printf("%s\n", get_exception_string(ex));
+            rethrow;
+        }
     }
 
     testInstanceMethods() {


### PR DESCRIPTION
…va ClassLoader context was not always set correctly when instantiating %Qore classes from Java when there were dependencies on dynamic classes, leading to class resolution errors

refs qorelanguage/qore#4372 fixed a bug where Java method args in array format were not always converted from Qore values correctly