### PR TITLE
Fix compiler diagnostics not captured in exception

### DIFF
--- a/docs/mainpage.dox.tmpl
+++ b/docs/mainpage.dox.tmpl
@@ -868,6 +868,9 @@ set_save_object_callback(callback);
       (<a href="https://github.com/qoretechnologies/qore/issues/5034">issue 5034</a>)
     - fixed a CMake bug where inner class inc file dependencies were not tracked correctly due to a typo
       (<a href="https://github.com/qoretechnologies/qore/issues/5034">issue 5034</a>)
+    - fixed a bug where Java compiler diagnostics were output to stderr instead of being captured in the
+      exception message
+      (<a href="https://github.com/qoretechnologies/qore/issues/4925">issue 4925</a>)
 
     @subsection jni_2_4_0 jni Module Version 2.4.0
     - added the <a href="../../ExcepDataProvider/html/index.html">ExcepDataProvider</a> module to allow for reading

--- a/src/java/org/qore/jni/compiler/QoreJavaCompiler.java
+++ b/src/java/org/qore/jni/compiler/QoreJavaCompiler.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.StringWriter;
 
 import java.nio.charset.StandardCharsets;
 
@@ -326,6 +327,13 @@ public class QoreJavaCompiler<T> {
             final Map<String, CharSequence> classes,
             final DiagnosticCollector<JavaFileObject> diagnosticsList)
             throws QoreJavaCompilerException {
+        // Always use a DiagnosticCollector to capture compiler diagnostics
+        DiagnosticCollector<JavaFileObject> localDiagnostics = diagnosticsList;
+        if (localDiagnostics == null) {
+            localDiagnostics = new DiagnosticCollector<JavaFileObject>();
+        }
+        diagnostics = localDiagnostics;
+
         List<JavaFileObject> sources = new ArrayList<JavaFileObject>();
         for (Entry<String, CharSequence> entry : classes.entrySet()) {
             String qualifiedClassName = entry.getKey();
@@ -345,13 +353,20 @@ public class QoreJavaCompiler<T> {
                         className + JAVA_EXTENSION, source);
             }
         }
+        // Use a StringWriter to capture any compiler output that would otherwise go to stderr
+        StringWriter compilerOutput = new StringWriter();
         try {
             // Get a CompliationTask from the compiler and compile the sources
-            final CompilationTask task = compiler.getTask(null, javaFileManager, diagnostics,
+            final CompilationTask task = compiler.getTask(compilerOutput, javaFileManager, localDiagnostics,
                     options, null, sources);
             final Boolean result = task.call();
             if (result == null || !result) {
-                throw new QoreJavaCompilerException("Compilation failed.", classes.keySet(), diagnostics);
+                String outputStr = compilerOutput.toString();
+                String message = "Compilation failed.";
+                if (!outputStr.isEmpty()) {
+                    message += " Compiler output: " + outputStr;
+                }
+                throw new QoreJavaCompilerException(message, classes.keySet(), localDiagnostics);
             }
             try {
                 // For each class name in the output map, get compiled class and file data and put it in the output map
@@ -366,11 +381,11 @@ public class QoreJavaCompiler<T> {
                 }
                 return compiled;
             } catch (ClassNotFoundException e) {
-                throw new QoreJavaCompilerException(classes.keySet(), e, diagnostics);
+                throw new QoreJavaCompilerException(classes.keySet(), e, localDiagnostics);
             } catch (IllegalArgumentException e) {
-                throw new QoreJavaCompilerException(classes.keySet(), e, diagnostics);
+                throw new QoreJavaCompilerException(classes.keySet(), e, localDiagnostics);
             } catch (SecurityException e) {
-                throw new QoreJavaCompilerException(classes.keySet(), e, diagnostics);
+                throw new QoreJavaCompilerException(classes.keySet(), e, localDiagnostics);
             }
         } finally {
             classLoader.clearCompilationCache();


### PR DESCRIPTION
## Summary

- Always create a `DiagnosticCollector` even if caller doesn't provide one
- Use `StringWriter` to capture compiler output that would go to stderr
- Include captured compiler output in exception message

Previously, compiler errors were output to stderr instead of being captured in the diagnostic object, resulting in "no compiler diagnostic output available" messages while the actual errors appeared on stderr.

## Changes

Modified `QoreJavaCompiler.java`:
- Added `StringWriter` to capture compiler output
- Pass writer to `compiler.getTask()` instead of `null`
- Create local `DiagnosticCollector` if none provided
- Include captured output in exception message

## Test plan

- [x] All 35 existing tests pass
- [x] Build succeeds with Java 25

Fixes: https://github.com/qoretechnologies/qore/issues/4925

🤖 Generated with [Claude Code](https://claude.com/claude-code)