### PR TITLE
Fix Java source locations missing in exception backtraces

### DIFF
--- a/src/Dispatcher.cpp
+++ b/src/Dispatcher.cpp
@@ -25,6 +25,7 @@
 //------------------------------------------------------------------------------
 #include "Dispatcher.h"
 #include "Array.h"
+#include "Globals.h"
 #include "Method.h"
 #include "QoreToJava.h"
 
@@ -74,6 +75,8 @@ jobject QoreCodeDispatcher::dispatch(Env& env, jobject proxy, jobject method, jo
         return nullptr;
     }
     QoreThreadDetacher qtd;
+
+    QoreJniStackLocationHelper slh;
 
     printd(LogLevel, "QoreCodeDispatcher::dispatch(), this: %p pgm: %p\n", this, pgm);
 

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -870,11 +870,6 @@ static jobject qore_object_closure_call_internal(JNIEnv* jenv, jclass, QoreProgr
                     m->getClassName(), m->getName(), v, m->getClass()->getID(), (int)len, obj);
                 val = obj->evalMethodVariant(*m, v, *qore_args, &xsink);
 
-                if (xsink) {
-                    QoreStringMaker desc("cls: '%s' mcls: '%s' valid: %d mvalid: %d", obj->getClassName(), m->getClass()->getName(), obj->isValid(), obj->validInstanceOfStrict(*m->getClass()));
-                    xsink.raiseException("INFO", desc.c_str());
-                }
-
                 // check for errors from objects with injected classes; make sure the error was raised due to
                 // injection issues
                 if (xsink && obj->isValid()

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -835,6 +835,8 @@ static jobject qore_object_closure_call_internal(JNIEnv* jenv, jclass, QoreProgr
         return nullptr;
     }
 
+    QoreJniStackLocationHelper slh;
+
     ExceptionSink xsink;
     try {
         // set program context before converting arguments


### PR DESCRIPTION
## Summary

- Added `QoreJniStackLocationHelper` to capture Java stack trace information in two entry points where it was missing
- Removed debug code that was left in production
- This ensures exception backtraces show proper Java source locations instead of `<builtin>:-1`

## Problem

When Java code calls Qore methods, exception backtraces showed:
```
AbstractTable::create() called at <builtin>:-1 (Qore user code)
JavaSimpleTestStep1::primary() called at <builtin>:-1 (Qore builtin code)
```

## Solution

Added `QoreJniStackLocationHelper slh;` to:
- `qore_object_closure_call_internal()` in `src/Globals.cpp` - handles Java calling Qore object methods and closures
- `QoreCodeDispatcher::dispatch()` in `src/Dispatcher.cpp` - handles Java invoking Qore callbacks

Also removed debug code that unconditionally added an "INFO" exception with class validation info.

## Test plan

- [x] All 36 existing tests pass
- [x] Build succeeds

Fixes https://github.com/qoretechnologies/qore/issues/5066

🤖 Generated with [Claude Code](https://claude.com/claude-code)