### PR TITLE
feat: add Kotlin runtime scripting support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ build/
 .settings/
 
 test/qore-jni-test.jar
+
+# Build artifacts - compiled Java classes and generated JARs in dataprovider directories
+qlib/*/jar/*.jar
+src/java/org/qore/dataprovider/excel/*.class
+src/java/org/qore/dataprovider/kafka/*.class

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(module_name "jni")
 project(qore-jni-module)
 
 set (VERSION_MAJOR 2)
-set (VERSION_MINOR 5)
+set (VERSION_MINOR 6)
 set (VERSION_PATCH 0)
 
 set (BYTE_BUDDY_JAR ${CMAKE_SOURCE_DIR}/byte-buddy/byte-buddy-1.14.19.jar)
@@ -260,6 +260,7 @@ set (JNI_BIN_FILES
     bin/qjava2jar
     bin/qjavac
     bin/qkotlinc
+    bin/download-kotlin-scripting-jars
 )
 
 # Java sources built in to the binary module with an indication of inner classes, if any
@@ -284,6 +285,7 @@ generate_java(org/qore/jni/JavaClassBuilder.java 1 2 StaticEntry)
 generate_java(org/qore/jni/QoreJavaFileObject.java)
 generate_java(org/qore/jni/QoreJavaObjectPtr.java)
 add_java_source(org/qore/jni/KotlinMetadataHelper.java)
+add_java_source(org/qore/jni/KotlinScriptEngine.java)
 generate_jar(${BYTE_BUDDY_JAR} JavaJarByteBuddy)
 
 # add Java sources without native methods

--- a/bin/download-kotlin-scripting-jars
+++ b/bin/download-kotlin-scripting-jars
@@ -1,0 +1,144 @@
+#!/bin/bash
+#
+# Downloads Kotlin JSR-223 scripting JARs from Maven Central.
+# These JARs are required for kotlin_eval() and the kotlin-eval module command.
+#
+# Usage: download-kotlin-scripting-jars [output-directory]
+#
+# If no output directory is specified, JARs are downloaded to the current directory.
+#
+# Copyright (C) 2016 - 2026 Qore Technologies, s.r.o.
+#
+
+set -e
+
+# Default Kotlin version - should match the installed kotlinc version
+KOTLIN_VERSION="${KOTLIN_VERSION:-2.1.0}"
+
+# Output directory
+OUTPUT_DIR="${1:-.}"
+
+# Maven Central base URL
+MAVEN_BASE="https://repo1.maven.org/maven2/org/jetbrains/kotlin"
+
+# Required JARs for JSR-223 scripting
+JARS=(
+    "kotlin-scripting-jsr223:kotlin-scripting-jsr223"
+    "kotlin-scripting-compiler-embeddable:kotlin-scripting-compiler-embeddable"
+    "kotlin-scripting-compiler-impl-embeddable:kotlin-scripting-compiler-impl-embeddable"
+    "kotlin-compiler-embeddable:kotlin-compiler-embeddable"
+    "kotlin-script-runtime:kotlin-script-runtime"
+    "kotlin-scripting-common:kotlin-scripting-common"
+    "kotlin-scripting-jvm:kotlin-scripting-jvm"
+    "kotlin-scripting-jvm-host:kotlin-scripting-jvm-host"
+)
+
+# Additional JARs from kotlinx (different Maven group)
+KOTLINX_JARS=(
+    "kotlinx-coroutines-core-jvm:1.8.1"
+)
+
+KOTLINX_BASE="https://repo1.maven.org/maven2/org/jetbrains/kotlinx"
+
+# Try to detect Kotlin version from kotlinc
+detect_kotlin_version() {
+    if command -v kotlinc &> /dev/null; then
+        local version=$(kotlinc -version 2>&1 | grep -oP 'kotlinc-jvm \K[0-9]+\.[0-9]+\.[0-9]+' || true)
+        if [ -n "$version" ]; then
+            echo "$version"
+            return
+        fi
+    fi
+    echo "$KOTLIN_VERSION"
+}
+
+# Download a JAR from Maven
+download_jar() {
+    local artifact="$1"
+    local name="$2"
+    local version="$3"
+    local url="${MAVEN_BASE}/${artifact}/${version}/${name}-${version}.jar"
+    local output="${OUTPUT_DIR}/${name}-${version}.jar"
+
+    if [ -f "$output" ]; then
+        echo "Already exists: $output"
+        return 0
+    fi
+
+    echo "Downloading: $name-$version.jar"
+    if curl -fsSL -o "$output" "$url"; then
+        echo "  -> $output"
+        return 0
+    else
+        echo "  FAILED to download: $url"
+        return 1
+    fi
+}
+
+# Download a kotlinx JAR from Maven
+download_kotlinx_jar() {
+    local name="$1"
+    local version="$2"
+    local url="${KOTLINX_BASE}/${name}/${version}/${name}-${version}.jar"
+    local output="${OUTPUT_DIR}/${name}-${version}.jar"
+
+    if [ -f "$output" ]; then
+        echo "Already exists: $output"
+        return 0
+    fi
+
+    echo "Downloading: $name-$version.jar"
+    if curl -fsSL -o "$output" "$url"; then
+        echo "  -> $output"
+        return 0
+    else
+        echo "  FAILED to download: $url"
+        return 1
+    fi
+}
+
+# Main
+main() {
+    local version=$(detect_kotlin_version)
+    echo "Kotlin version: $version"
+    echo "Output directory: $OUTPUT_DIR"
+    echo ""
+
+    mkdir -p "$OUTPUT_DIR"
+
+    local failed=0
+    echo "Downloading Kotlin scripting JARs..."
+    for jar_spec in "${JARS[@]}"; do
+        IFS=':' read -r artifact name <<< "$jar_spec"
+        if ! download_jar "$artifact" "$name" "$version"; then
+            ((failed++))
+        fi
+    done
+
+    echo ""
+    echo "Downloading kotlinx JARs..."
+    for jar_spec in "${KOTLINX_JARS[@]}"; do
+        IFS=':' read -r name ver <<< "$jar_spec"
+        if ! download_kotlinx_jar "$name" "$ver"; then
+            ((failed++))
+        fi
+    done
+
+    echo ""
+    if [ $failed -eq 0 ]; then
+        echo "All JARs downloaded successfully."
+        echo ""
+        echo "To use with Qore JNI module, add these JARs to the classpath:"
+        echo "  %module-cmd(jni) add-classpath ${OUTPUT_DIR}"
+        echo ""
+        echo "Or set CLASSPATH environment variable:"
+        echo "  export CLASSPATH=\"\$CLASSPATH:${OUTPUT_DIR}/*\""
+    else
+        echo "WARNING: $failed JAR(s) failed to download."
+        echo "Some JARs may not be available for Kotlin version $version."
+        echo "Try setting KOTLIN_VERSION environment variable to a different version."
+        exit 1
+    fi
+}
+
+main "$@"

--- a/docs/mainpage.dox.tmpl
+++ b/docs/mainpage.dox.tmpl
@@ -56,6 +56,12 @@
         object of the given type and size
     |@ref Jni::org::qore::jni::set_save_object_callback() "set_save_object_callback()"|Sets the object lifecycle \
         management callback; see @ref jni_qore_object_lifecycle_management for more information
+    |@ref Jni::org::qore::jni::kotlin_eval() "kotlin_eval()"|Evaluates a Kotlin script at runtime and returns the \
+        result; requires kotlin-scripting JARs
+    |@ref Jni::org::qore::jni::kotlin_scripting_available() "kotlin_scripting_available()"|Returns @ref True if \
+        Kotlin scripting is available (kotlin-scripting JARs are in the classpath)
+    |@ref Jni::org::qore::jni::kotlin_scripting_retry() "kotlin_scripting_retry()"|Retries Kotlin scripting \
+        initialization after loading additional JARs at runtime
 
     @section jni_examples Examples
 
@@ -911,6 +917,11 @@ set_save_object_callback(callback);
       - added automatic filtering of Kotlin companion object classes (\c $Companion)
       - added \c KotlinMetadataHelper Java class for detecting Kotlin classes via \c @kotlin.Metadata annotation
       - added \c qkotlinc helper script for compiling Kotlin sources that use Qore APIs
+      - added \c kotlin_eval() function for runtime Kotlin scripting (requires kotlin-scripting-jsr223 JARs)
+      - added \c kotlin_scripting_available() function to check if scripting is available
+      - added \c kotlin_scripting_retry() function to retry scripting initialization after loading JARs
+      - added \c kotlin-eval module command for parse-time Kotlin evaluation
+      - added \c download-kotlin-scripting-jars script to download required JARs from Maven
     - added Kotlin integration tests
 
     @subsection jni_2_5_0 jni Module Version 2.5.0

--- a/qore-jni-module.spec
+++ b/qore-jni-module.spec
@@ -5,7 +5,7 @@
 %global user_module_dir %{mydatarootdir}/qore-modules/
 
 Name:           qore-jni-module
-Version:        2.5.0
+Version:        2.6.0
 Release:        1
 Summary:        Qorus Integration Engine - Qore jni module
 License:        MIT
@@ -39,6 +39,9 @@ Requires:       qore >= 1.0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Requires:       java-21-openjdk-devel
 Requires:       java-21-openjdk
+# Kotlin is optional - only needed for kotlin_eval() scripting support
+# Basic Kotlin class support works with just kotlin-stdlib in the classpath
+Suggests:       kotlin
 %if 0%{?el8}
 # disable automatic library dependencies due to broken java 11 lib handling in centos 8
 AutoReqProv: no
@@ -76,6 +79,7 @@ make DESTDIR=%{buildroot} install %{?_smp_mflags}
 %{_bindir}/qjava2jar
 %{_bindir}/qjavac
 %{_bindir}/qkotlinc
+%{_bindir}/download-kotlin-scripting-jars
 %dir /usr/share/qore/java
 /usr/share/qore/java/qore-jni-compiler.jar
 /usr/share/qore/java/qore-jni.jar
@@ -94,6 +98,13 @@ This RPM provides API documentation, test and example programs
 %doc docs/jni test/*.qtest test/*.jar test/*.java
 
 %changelog
+* Sat Jan 4 2026 David Nichols <david@qore.org>
+- updated to version 2.6.0
+- added full Kotlin language integration support
+- added kotlin_eval(), kotlin_scripting_available(), kotlin_scripting_retry() functions
+- added download-kotlin-scripting-jars script for downloading scripting JARs from Maven
+- added qkotlinc helper script for compiling Kotlin sources using Qore APIs
+
 * Sat Dec 28 2024 David Nichols <david@qore.org>
 - updated to version 2.5.0
 - requires Java 21+ for compatibility with Java 25

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -219,6 +219,13 @@ jmethodID Globals::methodKotlinMetadataHelperIsDataClass;
 jmethodID Globals::methodKotlinMetadataHelperIsFileFacade;
 jmethodID Globals::methodKotlinMetadataHelperIsKotlinRuntimeAvailable;
 
+GlobalReference<jclass> Globals::classKotlinScriptEngine;
+jmethodID Globals::methodKotlinScriptEngineIsAvailable;
+jmethodID Globals::methodKotlinScriptEngineGetInitError;
+jmethodID Globals::methodKotlinScriptEngineEval;
+jmethodID Globals::methodKotlinScriptEngineEvalWithBindings;
+jmethodID Globals::methodKotlinScriptEngineRetryInit;
+
 GlobalReference<jclass> Globals::classGraphicsEnvironment;
 jmethodID Globals::methodGraphicsEnvironmentIsHeadless;
 
@@ -3087,6 +3094,78 @@ void Globals::initKotlinMetadataHelper() {
     std::call_once(kotlinMetadataHelperInitFlag, doInitKotlinMetadataHelper);
 }
 
+static std::mutex kotlinScriptEngineMutex;
+static bool kotlinScriptEngineInitAttempted = false;
+
+void Globals::initKotlinScriptEngine() {
+    // If already initialized successfully, nothing to do
+    if (classKotlinScriptEngine) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(kotlinScriptEngineMutex);
+
+    // Double-check after acquiring lock
+    if (classKotlinScriptEngine) {
+        return;
+    }
+
+    // If we've already attempted and failed, don't retry automatically
+    // The user can call retryInit() to force a retry
+    if (kotlinScriptEngineInitAttempted) {
+        return;
+    }
+
+    kotlinScriptEngineInitAttempted = true;
+
+    Env env;
+    // Try to find the class - first try the builtin classloader, then the program classloader
+    try {
+        classKotlinScriptEngine = env.findClass("org/qore/jni/KotlinScriptEngine").makeGlobal();
+    } catch (jni::Exception& e) {
+        e.ignore();
+        // Try with the program classloader
+        JniExternalProgramData* jpc = jni_get_context();
+        if (jpc) {
+            try {
+                LocalReference<jstring> jname = env.newString("org.qore.jni.KotlinScriptEngine");
+                jvalue jarg;
+                jarg.l = jname;
+                classKotlinScriptEngine = env.callObjectMethod(jpc->getClassLoader(),
+                    methodQoreURLClassLoaderLoadClass, &jarg).as<jclass>().makeGlobal();
+            } catch (jni::Exception& e2) {
+                printd(5, "KotlinScriptEngine not available via program classloader\n");
+                e2.ignore();
+                kotlinScriptEngineInitAttempted = false;
+                return;
+            }
+        } else {
+            printd(5, "KotlinScriptEngine not available - no program context\n");
+            kotlinScriptEngineInitAttempted = false;
+            return;
+        }
+    }
+
+    try {
+        methodKotlinScriptEngineIsAvailable = env.getStaticMethod(classKotlinScriptEngine,
+            "isAvailable", "()Z");
+        methodKotlinScriptEngineGetInitError = env.getStaticMethod(classKotlinScriptEngine,
+            "getInitError", "()Ljava/lang/String;");
+        methodKotlinScriptEngineEval = env.getStaticMethod(classKotlinScriptEngine,
+            "eval", "(Ljava/lang/String;)Ljava/lang/Object;");
+        methodKotlinScriptEngineEvalWithBindings = env.getStaticMethod(classKotlinScriptEngine,
+            "evalWithBindings", "(Ljava/lang/String;Ljava/util/HashMap;)Ljava/lang/Object;");
+        methodKotlinScriptEngineRetryInit = env.getStaticMethod(classKotlinScriptEngine,
+            "retryInit", "()Z");
+    } catch (jni::Exception& e) {
+        // Failed to get methods - reset
+        printd(5, "KotlinScriptEngine method lookup failed\n");
+        e.ignore();
+        classKotlinScriptEngine = nullptr;
+        kotlinScriptEngineInitAttempted = false;
+    }
+}
+
 void Globals::cleanup() {
     // delete classes
     classThrowable = nullptr;
@@ -3126,6 +3205,7 @@ void Globals::cleanup() {
     classQoreURLClassLoader = nullptr;
     classJavaClassBuilder = nullptr;
     classKotlinMetadataHelper = nullptr;
+    classKotlinScriptEngine = nullptr;
     classGraphicsEnvironment = nullptr;
     classThread = nullptr;
     classHashMap = nullptr;

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -3098,14 +3098,9 @@ static std::mutex kotlinScriptEngineMutex;
 static bool kotlinScriptEngineInitAttempted = false;
 
 void Globals::initKotlinScriptEngine() {
-    // If already initialized successfully, nothing to do
-    if (classKotlinScriptEngine) {
-        return;
-    }
-
     std::lock_guard<std::mutex> lock(kotlinScriptEngineMutex);
 
-    // Double-check after acquiring lock
+    // If already initialized successfully, nothing to do
     if (classKotlinScriptEngine) {
         return;
     }

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -229,6 +229,17 @@ public:
     DLLLOCAL static jmethodID methodKotlinMetadataHelperIsFileFacade;            // static boolean isFileFacade(Class<?>)
     DLLLOCAL static jmethodID methodKotlinMetadataHelperIsKotlinRuntimeAvailable; // static boolean isKotlinRuntimeAvailable()
 
+    // Kotlin script engine helper class
+    DLLLOCAL static GlobalReference<jclass> classKotlinScriptEngine;              // org.qore.jni.KotlinScriptEngine
+    DLLLOCAL static jmethodID methodKotlinScriptEngineIsAvailable;                // static boolean isAvailable()
+    DLLLOCAL static jmethodID methodKotlinScriptEngineGetInitError;               // static String getInitError()
+    DLLLOCAL static jmethodID methodKotlinScriptEngineEval;                       // static Object eval(String)
+    DLLLOCAL static jmethodID methodKotlinScriptEngineEvalWithBindings;           // static Object evalWithBindings(String, HashMap)
+    DLLLOCAL static jmethodID methodKotlinScriptEngineRetryInit;                  // static boolean retryInit()
+
+    // Lazily initialize the KotlinScriptEngine class (can retry if failed)
+    DLLLOCAL static void initKotlinScriptEngine();
+
     // to check for headless AWT to avoid importing classes that cannot be initialized when headless
     DLLLOCAL static GlobalReference<jclass> classGraphicsEnvironment;             // java.awt.GraphicsEnvironment
     DLLLOCAL static jmethodID methodGraphicsEnvironmentIsHeadless;                // boolean GraphicsEnvironment.isHeadless()

--- a/src/java/org/qore/jni/KotlinScriptEngine.java
+++ b/src/java/org/qore/jni/KotlinScriptEngine.java
@@ -1,0 +1,167 @@
+/*
+    KotlinScriptEngine.java
+
+    Helper class for Kotlin JSR-223 scripting integration.
+    Provides lazy initialization and evaluation of Kotlin scripts.
+
+    Copyright (C) 2016 - 2026 Qore Technologies, s.r.o.
+*/
+
+package org.qore.jni;
+
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
+import javax.script.Bindings;
+import javax.script.SimpleBindings;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Helper class for Kotlin scripting via JSR-223.
+ *
+ * Provides lazy initialization of the Kotlin script engine and methods
+ * to evaluate Kotlin code from Qore. The script engine is only initialized
+ * when first needed, and will fail gracefully if the required Kotlin
+ * scripting JARs are not available.
+ *
+ * Required JARs (in KOTLIN_HOME/lib or classpath):
+ * - kotlin-scripting-jsr223.jar
+ * - kotlin-scripting-compiler-embeddable.jar
+ * - kotlin-compiler-embeddable.jar
+ * - kotlin-stdlib.jar
+ * - kotlin-script-runtime.jar
+ */
+public class KotlinScriptEngine {
+    private static volatile ScriptEngine engine = null;
+    private static volatile boolean initAttempted = false;
+    private static volatile String initError = null;
+    private static final Object lock = new Object();
+
+    /**
+     * Check if Kotlin scripting is available.
+     *
+     * @return true if the Kotlin script engine can be initialized
+     */
+    public static boolean isAvailable() {
+        ensureInitialized();
+        return engine != null;
+    }
+
+    /**
+     * Get the initialization error message, if any.
+     *
+     * @return the error message or null if initialization succeeded
+     */
+    public static String getInitError() {
+        ensureInitialized();
+        return initError;
+    }
+
+    /**
+     * Evaluate a Kotlin script and return the result.
+     *
+     * @param script the Kotlin code to evaluate
+     * @return the result of evaluating the script
+     * @throws Exception if evaluation fails or scripting is not available
+     */
+    public static Object eval(String script) throws Exception {
+        ensureInitialized();
+        if (engine == null) {
+            throw new RuntimeException("Kotlin scripting not available: " +
+                (initError != null ? initError : "unknown error"));
+        }
+        try {
+            return engine.eval(script);
+        } catch (ScriptException e) {
+            throw new RuntimeException("Kotlin script error: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Evaluate a Kotlin script with bindings and return the result.
+     *
+     * @param script the Kotlin code to evaluate
+     * @param bindings a map of variable names to values to bind in the script
+     * @return the result of evaluating the script
+     * @throws Exception if evaluation fails or scripting is not available
+     */
+    public static Object evalWithBindings(String script, HashMap<String, Object> bindings) throws Exception {
+        ensureInitialized();
+        if (engine == null) {
+            throw new RuntimeException("Kotlin scripting not available: " +
+                (initError != null ? initError : "unknown error"));
+        }
+        try {
+            Bindings b = new SimpleBindings();
+            if (bindings != null) {
+                b.putAll(bindings);
+            }
+            return engine.eval(script, b);
+        } catch (ScriptException e) {
+            throw new RuntimeException("Kotlin script error: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Initialize the Kotlin script engine if not already done.
+     * Thread-safe lazy initialization.
+     */
+    private static void ensureInitialized() {
+        if (!initAttempted) {
+            synchronized (lock) {
+                if (!initAttempted) {
+                    try {
+                        ScriptEngineManager manager = new ScriptEngineManager();
+                        engine = manager.getEngineByExtension("kts");
+                        if (engine == null) {
+                            // Try by name as fallback
+                            engine = manager.getEngineByName("kotlin");
+                        }
+                        if (engine == null) {
+                            initError = "Kotlin script engine not found. " +
+                                "Ensure kotlin-scripting-jsr223.jar and related JARs are in the classpath. " +
+                                "Required: kotlin-scripting-jsr223, kotlin-scripting-compiler-embeddable, " +
+                                "kotlin-compiler-embeddable, kotlin-script-runtime";
+                        }
+                    } catch (Exception e) {
+                        initError = "Failed to initialize Kotlin script engine: " + e.getMessage();
+                        engine = null;
+                    } finally {
+                        initAttempted = true;
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Reset the script engine (for testing purposes).
+     * Forces re-initialization on next use.
+     */
+    public static void reset() {
+        synchronized (lock) {
+            engine = null;
+            initAttempted = false;
+            initError = null;
+        }
+    }
+
+    /**
+     * Retry initialization if it failed previously.
+     * Unlike reset(), this only retries if initialization failed.
+     *
+     * @return true if scripting is now available
+     */
+    public static boolean retryInit() {
+        synchronized (lock) {
+            if (engine == null) {
+                initAttempted = false;
+                initError = null;
+                ensureInitialized();
+            }
+            return engine != null;
+        }
+    }
+}
+

--- a/src/jni-module.cpp
+++ b/src/jni-module.cpp
@@ -104,6 +104,7 @@ static void qore_jni_mc_define_class(const QoreString& arg, QoreProgram* pgm, Jn
 static void qore_jni_mc_set_compat_types(const QoreString& arg, QoreProgram* pgm, JniExternalProgramData* jpc);
 static void qore_jni_mc_set_property(const QoreString& arg, QoreProgram* pgm, JniExternalProgramData* jpc);
 static void qore_jni_mc_mark_module_injected(const QoreString& arg, QoreProgram* pgm, JniExternalProgramData* jpc);
+static void qore_jni_mc_kotlin_eval(const QoreString& arg, QoreProgram* pgm, JniExternalProgramData* jpc);
 
 // module cmds
 typedef std::map<std::string, qore_jni_module_cmd_t> mcmap_t;
@@ -118,6 +119,7 @@ static mcmap_t mcmap = {
     {"set-compat-types", qore_jni_mc_set_compat_types},
     {"set-property", qore_jni_mc_set_property},
     {"mark-module-injected", qore_jni_mc_mark_module_injected},
+    {"kotlin-eval", qore_jni_mc_kotlin_eval},
 };
 
 static void jni_thread_cleanup(void*) {
@@ -569,6 +571,51 @@ static void qore_jni_mc_mark_module_injected(const QoreString& arg, QoreProgram*
     assert(jpc);
 
     jpc->addInjectedModule(arg.c_str());
+}
+
+static void qore_jni_mc_kotlin_eval(const QoreString& arg, QoreProgram* pgm, JniExternalProgramData* jpc) {
+    assert(pgm);
+    assert(pgm->checkFeature(QORE_JNI_MODULE_NAME));
+    assert(jpc);
+
+    // Initialize the Kotlin script engine if not already done
+    Globals::initKotlinScriptEngine();
+
+    if (!Globals::classKotlinScriptEngine) {
+        throw QoreJniException("KOTLIN-SCRIPTING-NOT-AVAILABLE",
+            "Kotlin scripting is not available - KotlinScriptEngine class not found");
+    }
+
+    jni::Env env;
+
+    // Check if scripting is available
+    jboolean available = env.callStaticBooleanMethod(Globals::classKotlinScriptEngine,
+        Globals::methodKotlinScriptEngineIsAvailable, nullptr);
+
+    if (!available) {
+        // Get the error message
+        LocalReference<jstring> errMsg = env.callStaticObjectMethod(Globals::classKotlinScriptEngine,
+            Globals::methodKotlinScriptEngineGetInitError, nullptr).as<jstring>();
+        if (errMsg) {
+            Env::GetStringUtfChars err(env, errMsg);
+            throw QoreJniException("KOTLIN-SCRIPTING-NOT-AVAILABLE",
+                "Kotlin scripting is not available: %s", err.c_str());
+        } else {
+            throw QoreJniException("KOTLIN-SCRIPTING-NOT-AVAILABLE",
+                "Kotlin scripting is not available - ensure kotlin-scripting-jsr223 JARs are in the classpath");
+        }
+    }
+
+    // Evaluate the Kotlin code
+    LocalReference<jstring> jscript = env.newString(arg.c_str());
+    std::vector<jvalue> jargs(1);
+    jargs[0].l = jscript;
+
+    LocalReference<jobject> result = env.callStaticObjectMethod(Globals::classKotlinScriptEngine,
+        Globals::methodKotlinScriptEngineEval, &jargs[0]);
+
+    // Result is discarded for module command - use kotlin_eval() function for return value
+    printd(5, "qore_jni_mc_kotlin_eval() executed Kotlin code successfully\n");
 }
 
 QoreClass* jni_class_handler(QoreNamespace* ns, const char* cname) {

--- a/src/ql_jni.qpp
+++ b/src/ql_jni.qpp
@@ -360,4 +360,158 @@ binary get_byte_code(string class_name) {
         return QoreValue();
     }
 }
+
+//! Evaluates Kotlin script code and returns the result
+/** @par Example:
+    @code{.py}
+auto result = kotlin_eval("1 + 2");  // returns 3
+    @endcode
+
+    @param script the Kotlin script code to evaluate
+
+    @return the result of evaluating the script
+
+    @throws KOTLIN-SCRIPTING-NOT-AVAILABLE if the Kotlin scripting JARs are not available
+    @throws KOTLIN-EVAL-ERROR if there is an error evaluating the script
+
+    @note This function requires the following JARs to be in the classpath:
+    - kotlin-scripting-jsr223.jar
+    - kotlin-scripting-compiler-embeddable.jar
+    - kotlin-compiler-embeddable.jar
+    - kotlin-script-runtime.jar
+
+    These JARs are typically found in KOTLIN_HOME/lib/
+
+    @since jni 2.6
+*/
+auto kotlin_eval(string script) {
+    try {
+        jni::Env env;
+
+        // Initialize the Kotlin script engine if not already done
+        Globals::initKotlinScriptEngine();
+
+        if (!Globals::classKotlinScriptEngine) {
+            xsink->raiseException("KOTLIN-SCRIPTING-NOT-AVAILABLE",
+                "Kotlin scripting is not available - KotlinScriptEngine class not found");
+            return QoreValue();
+        }
+
+        // Check if scripting is available
+        jboolean available = env.callStaticBooleanMethod(Globals::classKotlinScriptEngine,
+            Globals::methodKotlinScriptEngineIsAvailable, nullptr);
+
+        if (!available) {
+            // Get the error message
+            LocalReference<jstring> errMsg = env.callStaticObjectMethod(Globals::classKotlinScriptEngine,
+                Globals::methodKotlinScriptEngineGetInitError, nullptr).as<jstring>();
+            if (errMsg) {
+                Env::GetStringUtfChars err(env, errMsg);
+                xsink->raiseException("KOTLIN-SCRIPTING-NOT-AVAILABLE",
+                    "Kotlin scripting is not available: %s", err.c_str());
+            } else {
+                xsink->raiseException("KOTLIN-SCRIPTING-NOT-AVAILABLE",
+                    "Kotlin scripting is not available - ensure kotlin-scripting-jsr223 JARs are in the classpath");
+            }
+            return QoreValue();
+        }
+
+        // Evaluate the Kotlin code
+        LocalReference<jstring> jscript = env.newString(script->c_str());
+        std::vector<jvalue> jargs(1);
+        jargs[0].l = jscript;
+
+        LocalReference<jobject> result = env.callStaticObjectMethod(Globals::classKotlinScriptEngine,
+            Globals::methodKotlinScriptEngineEval, &jargs[0]);
+
+        if (!result) {
+            return QoreValue();
+        }
+
+        // Convert Java result to Qore value
+        QoreProgram* pgm = jni_get_program_context();
+        return JavaToQore::convertToQore(std::move(result), pgm);
+    } catch (jni::Exception& e) {
+        e.convert(xsink);
+        return QoreValue();
+    }
+}
+
+//! Returns @ref True if Kotlin scripting is available
+/** @par Example:
+    @code{.py}
+if (kotlin_scripting_available()) {
+    auto result = kotlin_eval("println(\"Hello from Kotlin!\")");
+}
+    @endcode
+
+    @return @ref True if Kotlin scripting JARs are available and the script engine can be initialized
+
+    @note This function checks for the availability of the Kotlin JSR-223 scripting engine.
+    It requires the following JARs to be in the classpath:
+    - kotlin-scripting-jsr223.jar
+    - kotlin-scripting-compiler-embeddable.jar
+    - kotlin-compiler-embeddable.jar
+    - kotlin-script-runtime.jar
+
+    @since jni 2.6
+*/
+bool kotlin_scripting_available() {
+    try {
+        jni::Env env;
+
+        // Initialize the Kotlin script engine if not already done
+        Globals::initKotlinScriptEngine();
+
+        if (!Globals::classKotlinScriptEngine) {
+            return false;
+        }
+
+        // Check if scripting is available
+        return (bool)env.callStaticBooleanMethod(Globals::classKotlinScriptEngine,
+            Globals::methodKotlinScriptEngineIsAvailable, nullptr);
+    } catch (jni::Exception& e) {
+        // Ignore exceptions - just return false
+        e.ignore();
+        return false;
+    }
+}
+
+//! Forces a retry of Kotlin script engine initialization after loading additional JARs
+/** @par Example:
+    @code{.py}
+# Load JARs dynamically
+classloader.addPath("/path/to/kotlin-scripting-jsr223.jar");
+# Retry initialization
+if (kotlin_scripting_retry()) {
+    auto result = kotlin_eval("1 + 2");
+}
+    @endcode
+
+    @return @ref True if Kotlin scripting is now available, @ref False otherwise
+
+    @note This function is useful when Kotlin scripting JARs are loaded at runtime
+    after the initial availability check returned @ref False.
+
+    @since jni 2.6
+*/
+bool kotlin_scripting_retry() {
+    try {
+        jni::Env env;
+
+        // Initialize the Kotlin script engine if not already done
+        Globals::initKotlinScriptEngine();
+
+        if (!Globals::classKotlinScriptEngine) {
+            return false;
+        }
+
+        // Call retryInit to force re-initialization if it failed before
+        return (bool)env.callStaticBooleanMethod(Globals::classKotlinScriptEngine,
+            Globals::methodKotlinScriptEngineRetryInit, nullptr);
+    } catch (jni::Exception& e) {
+        e.ignore();
+        return false;
+    }
+}
 ///@}

--- a/test/kotlin.qtest
+++ b/test/kotlin.qtest
@@ -315,7 +315,7 @@ public class KotlinTest inherits QUnit::Test {
         # Check for scripting JARs in common locations
         list<string> scriptingPaths = (
             "/tmp/kotlin-scripting",  # Downloaded by download-kotlin-scripting-jars script
-            ENV.HOME + "/.kotlin-scripting",
+            (ENV.HOME ?? "") + "/.kotlin-scripting",
             ENV.KOTLIN_SCRIPTING_JARS ?? "",
         );
 
@@ -367,8 +367,10 @@ public class KotlinTest inherits QUnit::Test {
             "/usr/share/kotlin",
             "/usr/lib/kotlin",
             "/usr/local/kotlin",
-            ENV.HOME + "/.sdkman/candidates/kotlin/current",
         );
+        if (ENV.HOME) {
+            homes += ENV.HOME + "/.sdkman/candidates/kotlin/current";
+        }
 
         foreach string home in (homes) {
             if (is_dir(home)) {

--- a/test/kotlin.qtest
+++ b/test/kotlin.qtest
@@ -17,6 +17,7 @@
 %disable-warning non-existent-method-call
 
 %requires jni
+%module-cmd(jni) add-relative-classpath ../build/qore-jni.jar
 %module-cmd(jni) add-relative-classpath kotlin-test.jar
 %module-cmd(jni) import org.qore.jni.QoreURLClassLoader
 
@@ -122,6 +123,10 @@ public class KotlinTest inherits QUnit::Test {
         addTestCase("Kotlin creating Qore object test", \kotlinCreateQoreObjectTest());
         addTestCase("Kotlin Hash interop test", \kotlinHashInteropTest());
         addTestCase("Kotlin get Qore library info test", \kotlinGetQoreLibraryInfoTest());
+
+        # Kotlin scripting tests (requires kotlin-scripting JARs)
+        addTestCase("Kotlin scripting availability test", \kotlinScriptingAvailabilityTest());
+        addTestCase("Kotlin eval test", \kotlinEvalTest());
 
         set_return_value(main());
     }
@@ -291,5 +296,152 @@ public class KotlinTest inherits QUnit::Test {
         hash<auto> h = result;
         assertTrue(h.hasKey("version"));
         assertEq(Qore::VersionString, h.version);
+    }
+
+    # =====================================================
+    # Kotlin scripting tests
+    # =====================================================
+
+    private {
+        bool scriptingJarsLoaded = False;
+    }
+
+    # Try to load Kotlin scripting JARs from common locations
+    private bool tryLoadScriptingJars() {
+        if (scriptingJarsLoaded) {
+            return True;
+        }
+
+        # Check for scripting JARs in common locations
+        list<string> scriptingPaths = (
+            "/tmp/kotlin-scripting",  # Downloaded by download-kotlin-scripting-jars script
+            ENV.HOME + "/.kotlin-scripting",
+            ENV.KOTLIN_SCRIPTING_JARS ?? "",
+        );
+
+        object classloader = QoreURLClassLoader::getCurrent();
+
+        foreach string basePath in (scriptingPaths) {
+            if (!basePath || !is_dir(basePath)) {
+                continue;
+            }
+
+            *list<string> jars = glob(basePath + "/*.jar");
+            if (!jars) {
+                continue;
+            }
+
+            # Found JARs, try to load them
+            foreach string jar in (jars) {
+                classloader.addPath(jar);
+            }
+
+            # Also add kotlin-reflect if available
+            *string kotlin_home = find_kotlin_home();
+            if (kotlin_home) {
+                string reflectJar = kotlin_home + "/lib/kotlin-reflect.jar";
+                if (is_file(reflectJar)) {
+                    classloader.addPath(reflectJar);
+                }
+            }
+
+            scriptingJarsLoaded = True;
+            # Force retry of Kotlin scripting initialization now that JARs are loaded
+            kotlin_scripting_retry();
+            return True;
+        }
+
+        return False;
+    }
+
+    # Find KOTLIN_HOME directory
+    private *string find_kotlin_home() {
+        *string kotlin_home = ENV.KOTLIN_HOME;
+        if (kotlin_home && is_dir(kotlin_home)) {
+            return kotlin_home;
+        }
+
+        # Common locations
+        list<string> homes = (
+            "/snap/kotlin/current",
+            "/usr/share/kotlin",
+            "/usr/lib/kotlin",
+            "/usr/local/kotlin",
+            ENV.HOME + "/.sdkman/candidates/kotlin/current",
+        );
+
+        foreach string home in (homes) {
+            if (is_dir(home)) {
+                return home;
+            }
+        }
+
+        # Try glob for snap
+        *list<string> snap_paths = glob("/snap/kotlin/*/lib");
+        if (snap_paths) {
+            return dirname(snap_paths[0]);
+        }
+
+        return NOTHING;
+    }
+
+    kotlinScriptingAvailabilityTest() {
+        # Test that kotlin_scripting_available() returns a boolean
+        # Without scripting JARs, it should return False
+        bool available = kotlin_scripting_available();
+        assertEq(Type::Boolean, available.type());
+
+        # Try to load scripting JARs
+        tryLoadScriptingJars();
+
+        # Check again - may or may not be True depending on whether JARs are present
+        available = kotlin_scripting_available();
+        assertEq(Type::Boolean, available.type());
+
+        if (!available) {
+            testSkip("Kotlin scripting JARs not available - skipping detailed scripting tests");
+        }
+    }
+
+    kotlinEvalTest() {
+        # Try to load scripting JARs first
+        tryLoadScriptingJars();
+
+        if (!kotlin_scripting_available()) {
+            testSkip("Kotlin scripting JARs not available - run download-kotlin-scripting-jars to enable");
+            return;
+        }
+
+        # Test basic arithmetic
+        assertEq(3, kotlin_eval("1 + 2"));
+
+        # Test string
+        assertEq("Hello, Qore!", kotlin_eval("\"Hello, Qore!\""));
+
+        # Test list operations
+        assertEq(6, kotlin_eval("listOf(1, 2, 3).sum()"));
+
+        # Test map creation
+        hash<auto> result = kotlin_eval("mapOf(\"a\" to 1, \"b\" to 2)");
+        assertEq(1, result.a);
+        assertEq(2, result.b);
+
+        # Test multiline script
+        string script = "
+            val x = 10
+            val y = 20
+            x + y
+        ";
+        assertEq(30, kotlin_eval(script));
+
+        # Test error handling
+        bool gotError = False;
+        try {
+            kotlin_eval("throw RuntimeException(\"test error\")");
+        } catch (hash<auto> ex) {
+            gotError = True;
+            assertTrue(ex.desc.find("test error") >= 0, "Exception should contain error message");
+        }
+        assertTrue(gotError, "kotlin_eval should throw on script errors");
     }
 }


### PR DESCRIPTION
## Summary
Adds runtime Kotlin scripting support to the jni module via JSR-223 scripting API.

refs qoretechnologies/qore#5132

## New Features
- `kotlin_eval()` function - evaluates Kotlin code at runtime and returns the result
- `kotlin_scripting_available()` function - checks if scripting JARs are loaded
- `kotlin_scripting_retry()` function - retries initialization after loading JARs dynamically
- `kotlin-eval` module command - parse-time Kotlin evaluation
- `download-kotlin-scripting-jars` script - downloads required JARs from Maven Central

## Implementation Details
- Uses JSR-223 scripting API with lazy initialization in `KotlinScriptEngine.java`
- Thread-safe initialization with mutex-based retry capability in C++
- Uses program classloader (QoreURLClassLoader) to find classes from qore-jni.jar
- Graceful degradation when scripting JARs are not available

## Files Changed
| File | Changes |
|------|---------|
| `src/java/org/qore/jni/KotlinScriptEngine.java` | NEW - Java wrapper for JSR-223 scripting |
| `bin/download-kotlin-scripting-jars` | NEW - Maven download script |
| `src/Globals.cpp/h` | KotlinScriptEngine JNI initialization |
| `src/ql_jni.qpp` | 3 new Qore functions |
| `src/jni-module.cpp` | kotlin-eval module command |
| `test/kotlin.qtest` | Scripting tests with graceful skip |
| `docs/mainpage.dox.tmpl` | Documentation and release notes |
| `CMakeLists.txt` | Version bump to 2.6.0 |
| `qore-jni-module.spec` | Version, changelog, Kotlin dependency |

## Test plan
- [x] Tests pass with scripting JARs available (35 assertions)
- [x] Tests gracefully skip when JARs unavailable (27 assertions)
- [x] Main jni.qtest passes (377 assertions)
- [x] Valgrind shows no new memory issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)