### PR TITLE
Fix Kotlin test failures, suppress JVM unsafe warnings

### DIFF
--- a/bin/download-kotlin-scripting-jars
+++ b/bin/download-kotlin-scripting-jars
@@ -13,10 +13,35 @@
 set -e
 
 # Default Kotlin version - should match the installed kotlinc version
-KOTLIN_VERSION="${KOTLIN_VERSION:-2.1.0}"
+KOTLIN_VERSION="${KOTLIN_VERSION:-2.3.0}"
 
-# Output directory
-OUTPUT_DIR="${1:-.}"
+# Find KOTLIN_HOME
+find_kotlin_home() {
+    if [ -n "$KOTLIN_HOME" ] && [ -d "$KOTLIN_HOME" ]; then
+        echo "$KOTLIN_HOME"
+        return
+    fi
+    for dir in /opt/kotlin /opt/kotlinc /usr/share/kotlin /usr/lib/kotlin /usr/local/kotlin; do
+        if [ -d "$dir/lib" ]; then
+            echo "$dir"
+            return
+        fi
+    done
+}
+
+# Output directory: use argument if provided, otherwise KOTLIN_HOME/lib/scripting
+if [ -n "$1" ]; then
+    OUTPUT_DIR="$1"
+else
+    _kotlin_home=$(find_kotlin_home)
+    if [ -n "$_kotlin_home" ]; then
+        OUTPUT_DIR="${_kotlin_home}/lib/scripting"
+    else
+        OUTPUT_DIR="."
+        echo "WARNING: KOTLIN_HOME not found; downloading to current directory"
+        echo "Set KOTLIN_HOME or pass an output directory as argument"
+    fi
+fi
 
 # Maven Central base URL
 MAVEN_BASE="https://repo1.maven.org/maven2/org/jetbrains/kotlin"
@@ -42,8 +67,18 @@ KOTLINX_BASE="https://repo1.maven.org/maven2/org/jetbrains/kotlinx"
 
 # Try to detect Kotlin version from kotlinc
 detect_kotlin_version() {
+    local kotlinc_cmd=""
     if command -v kotlinc &> /dev/null; then
-        local version=$(kotlinc -version 2>&1 | grep -oP 'kotlinc-jvm \K[0-9]+\.[0-9]+\.[0-9]+' || true)
+        kotlinc_cmd="kotlinc"
+    else
+        # Check KOTLIN_HOME and common locations
+        local kh=$(find_kotlin_home)
+        if [ -n "$kh" ] && [ -x "$kh/bin/kotlinc" ]; then
+            kotlinc_cmd="$kh/bin/kotlinc"
+        fi
+    fi
+    if [ -n "$kotlinc_cmd" ]; then
+        local version=$($kotlinc_cmd -version 2>&1 | grep -oP 'kotlinc-jvm \K[0-9]+\.[0-9]+\.[0-9]+' || true)
         if [ -n "$version" ]; then
             echo "$version"
             return
@@ -104,7 +139,11 @@ main() {
     echo "Output directory: $OUTPUT_DIR"
     echo ""
 
-    mkdir -p "$OUTPUT_DIR"
+    if ! mkdir -p "$OUTPUT_DIR" 2>/dev/null; then
+        echo "ERROR: Cannot create directory: $OUTPUT_DIR"
+        echo "Try running with sudo or specify a writable output directory"
+        exit 1
+    fi
 
     local failed=0
     echo "Downloading Kotlin scripting JARs..."

--- a/src/Jvm.cpp
+++ b/src/Jvm.cpp
@@ -49,6 +49,10 @@ QoreStringNode* Jvm::createVM() {
     bool disable_jit = false;
     bool enable_native_access = true;
     bool native_access_explicit = false;
+#if JAVA_VERSION_MAJOR >= 23
+    bool suppress_unsafe_warnings = true;
+    bool unsafe_warnings_explicit = false;
+#endif
     QoreString min_heap, max_heap, debug_cmd, native_access_opt;
     std::vector<std::string> strvec;
     // check QORE_JNI_DISABLE_JIT environment variable
@@ -78,6 +82,16 @@ QoreStringNode* Jvm::createVM() {
             }
         }
     }
+#if JAVA_VERSION_MAJOR >= 23
+    {
+        QoreString val;
+        if (!SystemEnvironment::get("QORE_JNI_DISABLE_UNSAFE_WARNING_SUPPRESSION", val)) {
+            if (q_parse_bool(val.c_str())) {
+                suppress_unsafe_warnings = false;
+            }
+        }
+    }
+#endif
     {
         QoreString val;
         if (!SystemEnvironment::get("QORE_JNI_DEBUG", val)) {
@@ -95,6 +109,11 @@ QoreStringNode* Jvm::createVM() {
             if (val.find("--enable-native-access") >= 0) {
                 native_access_explicit = true;
             }
+#if JAVA_VERSION_MAJOR >= 23
+            if (val.find("--sun-misc-unsafe-memory-access") >= 0) {
+                unsafe_warnings_explicit = true;
+            }
+#endif
             ssize_t pos = 0;
             while (true) {
                 ssize_t i = val.find(' ', pos);
@@ -106,14 +125,19 @@ QoreStringNode* Jvm::createVM() {
                 // add option
                 std::string opt(val.c_str() + pos, i - pos);
                 strvec.push_back(opt);
+                pos = i + 1;
             }
-            // add final option
             num_options += strvec.size();
         }
     }
     if (enable_native_access && !native_access_explicit) {
         ++num_options;
     }
+#if JAVA_VERSION_MAJOR >= 23
+    if (suppress_unsafe_warnings && !unsafe_warnings_explicit) {
+        ++num_options;
+    }
+#endif
     native_access_option_enabled = enable_native_access;
 #ifdef QORE_JNI_SUPPORT_CLASSPATH
     // this is disabled, because we use our own URLClassloader now to load all classes
@@ -153,6 +177,14 @@ QoreStringNode* Jvm::createVM() {
         native_access_opt = "--enable-native-access=ALL-UNNAMED";
         options[vm_args.nOptions++].optionString = (char*)native_access_opt.c_str();
     }
+#if JAVA_VERSION_MAJOR >= 23
+    QoreString unsafe_warning_opt;
+    if (suppress_unsafe_warnings && !unsafe_warnings_explicit) {
+        // suppress warnings about terminally deprecated sun.misc.Unsafe methods
+        unsafe_warning_opt = "--sun-misc-unsafe-memory-access=allow";
+        options[vm_args.nOptions++].optionString = (char*)unsafe_warning_opt.c_str();
+    }
+#endif
     if (!strvec.empty()) {
         for (auto& str: strvec) {
             //printd(5, "adding JVM pption: '%s'\n", str.c_str());

--- a/test/KotlinQoreApiTest.kt
+++ b/test/KotlinQoreApiTest.kt
@@ -155,7 +155,7 @@ object KotlinQoreApiTest {
     @JvmStatic
     @Throws(Throwable::class)
     fun getQoreLibraryInfo(): HashMap<*, *> {
-        return QoreJavaApi.callFunction("get_qore_library_info") as HashMap<*, *>
+        return QoreJavaApi.callFunction("::get_qore_library_info") as HashMap<*, *>
     }
 
     /**

--- a/test/docker_test/test-alpine.sh
+++ b/test/docker_test/test-alpine.sh
@@ -67,6 +67,7 @@ fi
 
 # copy built data provider JARs to source tree for testing
 cp ${MODULE_SRC_DIR}/build/qore-dataprovider-excel.jar ${MODULE_SRC_DIR}/qlib/ExcelDataProvider/jar/
+mkdir -p ${MODULE_SRC_DIR}/qlib/WordDataProvider/jar
 cp ${MODULE_SRC_DIR}/build/qore-dataprovider-word.jar ${MODULE_SRC_DIR}/qlib/WordDataProvider/jar/
 cp ${MODULE_SRC_DIR}/build/qore-dataprovider-kafka.jar ${MODULE_SRC_DIR}/qlib/KafkaDataProvider/jar/
 

--- a/test/docker_test/test-alpine.sh
+++ b/test/docker_test/test-alpine.sh
@@ -65,6 +65,11 @@ if [ -n "$do_jms_test" ]; then
     gosu qore:qore ${PAYARA_HOME}/bin/asadmin create-jms-resource --restype javax.jms.Queue abc
 fi
 
+# copy built data provider JARs to source tree for testing
+cp ${MODULE_SRC_DIR}/build/qore-dataprovider-excel.jar ${MODULE_SRC_DIR}/qlib/ExcelDataProvider/jar/
+cp ${MODULE_SRC_DIR}/build/qore-dataprovider-word.jar ${MODULE_SRC_DIR}/qlib/WordDataProvider/jar/
+cp ${MODULE_SRC_DIR}/build/qore-dataprovider-kafka.jar ${MODULE_SRC_DIR}/qlib/KafkaDataProvider/jar/
+
 # run the tests
 export QORE_MODULE_DIR=${MODULE_SRC_DIR}/qlib:${QORE_MODULE_DIR}
 cd ${MODULE_SRC_DIR}

--- a/test/docker_test/test-ubuntu.sh
+++ b/test/docker_test/test-ubuntu.sh
@@ -61,6 +61,7 @@ fi
 
 # copy built data provider JARs to source tree for testing
 cp ${MODULE_SRC_DIR}/build/qore-dataprovider-excel.jar ${MODULE_SRC_DIR}/qlib/ExcelDataProvider/jar/
+mkdir -p ${MODULE_SRC_DIR}/qlib/WordDataProvider/jar
 cp ${MODULE_SRC_DIR}/build/qore-dataprovider-word.jar ${MODULE_SRC_DIR}/qlib/WordDataProvider/jar/
 cp ${MODULE_SRC_DIR}/build/qore-dataprovider-kafka.jar ${MODULE_SRC_DIR}/qlib/KafkaDataProvider/jar/
 

--- a/test/docker_test/test-ubuntu.sh
+++ b/test/docker_test/test-ubuntu.sh
@@ -59,6 +59,11 @@ if [ -n "$do_jms_test" ]; then
     gosu qore:qore ${PAYARA_HOME}/bin/asadmin create-jms-resource --restype javax.jms.Queue abc
 fi
 
+# copy built data provider JARs to source tree for testing
+cp ${MODULE_SRC_DIR}/build/qore-dataprovider-excel.jar ${MODULE_SRC_DIR}/qlib/ExcelDataProvider/jar/
+cp ${MODULE_SRC_DIR}/build/qore-dataprovider-word.jar ${MODULE_SRC_DIR}/qlib/WordDataProvider/jar/
+cp ${MODULE_SRC_DIR}/build/qore-dataprovider-kafka.jar ${MODULE_SRC_DIR}/qlib/KafkaDataProvider/jar/
+
 # run the tests
 export QORE_MODULE_DIR=${MODULE_SRC_DIR}/qlib:${QORE_MODULE_DIR}
 cd ${MODULE_SRC_DIR}

--- a/test/jni.qtest
+++ b/test/jni.qtest
@@ -993,7 +993,7 @@ public class QoreArgTest extends ArgTest {
 
             msg.addTO(To);
 
-            msg.attach("foo.txt", MimeTypeText, "lorem ipsum", EncBase64);
+            msg.attach("foo.txt", MimeTypeText, "lorem ipsum", ContentEncoding::Base64);
             string r = msg.serialize();
 
             string refstr = "From: foo@bar.cz\r
@@ -1028,7 +1028,7 @@ bG9yZW0gaXBzdW0=\r
             msg.setBody("body");
             msg.addTO(To);
 
-            msg.attach("foo.txt", MimeTypeText, "lorem ipsum", EncDefault);
+            msg.attach("foo.txt", MimeTypeText, "lorem ipsum", ContentEncoding::Default);
             string r = msg.serialize();
 
             string refstr = "From: foo@bar.cz\r

--- a/test/kotlin.qtest
+++ b/test/kotlin.qtest
@@ -836,10 +836,16 @@ public class KotlinTest inherits QUnit::Test {
 
         # Check for scripting JARs in common locations
         list<string> scriptingPaths = (
-            "/tmp/kotlin-scripting",  # Downloaded by download-kotlin-scripting-jars script
+            "/tmp/kotlin-scripting",  # Legacy location
             (ENV.HOME ?? "") + "/.kotlin-scripting",
             ENV.KOTLIN_SCRIPTING_JARS ?? "",
         );
+
+        # Also check KOTLIN_HOME/lib/scripting (default for download-kotlin-scripting-jars)
+        *string kotlin_home = find_kotlin_home();
+        if (kotlin_home) {
+            scriptingPaths += kotlin_home + "/lib/scripting";
+        }
 
         object classloader = QoreURLClassLoader::getCurrent();
 
@@ -859,7 +865,6 @@ public class KotlinTest inherits QUnit::Test {
             }
 
             # Also add kotlin-reflect if available
-            *string kotlin_home = find_kotlin_home();
             if (kotlin_home) {
                 string reflectJar = kotlin_home + "/lib/kotlin-reflect.jar";
                 if (is_file(reflectJar)) {


### PR DESCRIPTION
## Summary
- **Fix kotlinGetQoreLibraryInfoTest**: use fully-qualified `::get_qore_library_info()` to avoid namespace shadowing by the built-in Qore function after namespace resolution changes
- **Suppress sun.misc.Unsafe warnings** on Java 23+ by adding `--sun-misc-unsafe-memory-access=allow` JVM option (guarded by `#if JAVA_VERSION_MAJOR >= 23`, controllable via `QORE_JNI_DISABLE_UNSAFE_WARNING_SUPPRESSION` env var)
- **Fix infinite loop bug** in `QORE_JNI_JVM_ARGS` parsing when args contain spaces (missing `pos` advance)
- **Fix scripting JAR discovery**: `tryLoadScriptingJars()` now searches `KOTLIN_HOME/lib/scripting`; download script defaults to that location, auto-detects Kotlin version, defaults to Kotlin 2.3.0, and gives clear error on permission failures
- **Rebuild kotlin-test.jar** with Kotlin 2.3.0

## Test plan
- [x] `kotlin.qtest`: 42/42 test cases pass (78 assertions), no warnings
- [ ] Verify on Java 21/22 build that `#if JAVA_VERSION_MAJOR >= 23` guard prevents unrecognized JVM option
- [ ] Verify `QORE_JNI_DISABLE_UNSAFE_WARNING_SUPPRESSION=1` re-enables warnings on Java 23+
- [ ] Verify `download-kotlin-scripting-jars` fails gracefully without sudo on system paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)